### PR TITLE
Solved: App only shows 270 Gists

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -20,6 +20,7 @@
             window.gui = require('nw.gui');
             var clipboard = window.gui.Clipboard.get();
         }
+	
     </script>
 
 </head>
@@ -32,7 +33,7 @@
         <h1 title="Gist desktop app"><a href="#/">
             <i class="icon-angle-left"></i>/Gisto<i class="icon-angle-right"></i>
         </a></h1>
-        <input list="gistDataList" type="text" data-ng-model="search" class="search-query" placeholder="Search gists">
+        <input list="gistDataList" type="text" ng-model="search" class="search-query" placeholder="Search gists">
         <!--
         <datalist id="gistDataList">
             <option data-ng-repeat="gist in gists" value="{{(gist.description | removeTags) || 'Untitled'}}"></option>
@@ -42,7 +43,7 @@
 
     <ul>
         <li id="gist-{{gist.id}}" class="animate-list"
-            data-ng-repeat="gist in filteredGists = (gists | filter:search) | orderBy:'-created_at'">
+            data-ng-repeat="gist in filteredGists = (gists | gistsearch:search) | orderBy:'-created_at'">
             <a ui-route="/gist/{{gist.id}}" data-ng-class="{active: $uiRoute}"
                ng-click="navigateToGist(gist.id)">
                 <h3>
@@ -55,7 +56,7 @@
                 <span class="pills gist-comment"><i class="icon-comments"></i> {{gist.comments}} Comment(s)</span>
                 <i class="icon-file"></i>
                 <ng-pluralize count="gist.filesCount" when="{'one': '1 file', 'other': '{} files'}"></ng-pluralize>
-
+				{{gist.filename}}
                 <span ng-if="gist.bigFile" class="pils gist-comment" title="This gist contains file over 1mb"><i class="icon-warning-sign"></i> big file</span>
 
                 <p>
@@ -125,6 +126,7 @@
 <script src="js/filters/publicOrPrivateFilter.js"></script>
 <script src="js/filters/dotToDash.js"></script>
 <script src="js/filters/githubFileName.js"></script>
+<script src="js/filters/gistsearchFilter.js"></script>
 <script src="js/directives/editorDirective.js"></script>
 <script src="js/directives/scrollDirective.js"></script>
 <script src="js/directives/goToUrlDirective.js"></script>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -15,6 +15,7 @@ angular.module('gisto', [
         'gisto.filter.removeTagSymbol',
         'gisto.filter.dotToDash',
         'gisto.filter.githubFileName',
+		'gisto.filter.gistsearch',
         'gisto.directive.scrollTo',
         'gisto.directive.editor',
         'gisto.directive.toUrl',

--- a/app/js/filters/gistsearchFilter.js
+++ b/app/js/filters/gistsearchFilter.js
@@ -1,0 +1,67 @@
+'use strict';
+
+angular.module('gisto.filter.gistsearch', []).filter('gistsearch', function () {
+	return function (items, searchterm) {		
+	
+		// if the searchterm is empy from the <input> then we simply return the items
+		if(searchterm === undefined) { return items; }
+		if(searchterm.length < 1) { return items; }
+		
+		// we need to split the searchterm, because you can search for separate terms
+		// splitted by space and you can also use quotes
+		// like single words "fixed string of words"
+
+		var myRegexp = /[^\s"]+|"([^"]*)"/gi;
+		var searchTermsArr = [];
+
+		do {
+			//Each call to exec returns the next regex match as an array
+			var match = myRegexp.exec(searchterm);
+			if (match != null)
+			{
+				//Index 1 in the array is the captured group if it exists
+				//Index 0 is the matched text, which we use if no captured group exists
+				searchTermsArr.push(match[1] ? match[1] : match[0]);
+			}
+		} while (match != null);
+
+		
+		var filtered = [];
+		
+		// iterate over all searchterms, if all match, either in the filename or in the description we add that item to the results
+		for (var i = 0; i < items.length; i++) {
+			var cItem = items[i];			
+		
+			var matchesAllSearchTerms = true;
+			var cDescription = "";
+			var cFilename = "";
+			for (var j = 0; j < searchTermsArr.length; j++) {	
+				var cSearchTerm = searchTermsArr[j].toLowerCase(); 
+				
+				cDescription = "";
+				if(items[i].description !== undefined) {
+					cDescription = items[i].description + "";
+					cDescription = cDescription.toLowerCase();
+				}
+				
+				cFilename = "";
+				if(items[i].filename !== undefined) {
+					cFilename = items[i].filename + "";
+					cFilename = cFilename.toLowerCase();
+				}				
+				
+				if(cDescription.indexOf(cSearchTerm) < 0 && cFilename.indexOf(cSearchTerm) < 0) {
+					matchesAllSearchTerms = false;
+				}			
+			}
+			
+			if(matchesAllSearchTerms) {
+				filtered.push(items[i]);
+			}
+		}
+		
+		
+		return filtered;;
+	};
+	
+});

--- a/app/js/services/githubApiService.js
+++ b/app/js/services/githubApiService.js
@@ -116,9 +116,11 @@ angular.module('gisto.service.gitHubAPI', [
                     });
                 });
             },
-
+			
             // GET /gists
-            gists: function (updateOnly, pageNumber) {
+            gists: function (updateOnly, pageNumber) {			
+
+
                 appSettings.loadSettings().then(function (result) {
                     var url = pageNumber ? api_url + '?page=' + pageNumber : api_url,
                         headers = {
@@ -134,19 +136,25 @@ angular.module('gisto.service.gitHubAPI', [
                         url: url,
                         headers: headers
                     }).success(function (data, status, headers, config) {
-                        for (var item in data) { // process and arrange data
+						
+						for (var item in data) { // process and arrange data							
                             data[item].tags = data[item].description ? data[item].description.match(/(#[A-Za-z0-9\-\_]+)/g) : [];
                             data[item].single = {};
-                            data[item].filesCount = Object.keys(data[item].files).length;
+                            data[item].filesCount = Object.keys(data[item].files).length;							
+							if(data[item].filesCount > 0) {
+								// save the first filename
+								// todo why not store all filenames?
+								data[item].filename = Object.keys(data[item].files)[0];								
+							}
                             angular.forEach(data[item].files,function(fileSize){
                                 if(fileSize.size > 1048576) {
                                     data[item].bigFile = true;
                                     console.info(' --- file size',fileSize.size);
                                 }
                             });
-                            console.info('data[item]',data[item]);
+                            //c onsole.info('data[item]',data[item]);
                         }
-						
+
                         // Set lastUpdated for 60 sec cache
                         data.lastUpdated = new Date();
 
@@ -158,7 +166,7 @@ angular.module('gisto.service.gitHubAPI', [
                             var links = header.link.split(',');
                             for (var link in links) {
                                 link = links[link];
-								console.log(link);
+								//c onsole.log(link);
                                 if (link.indexOf('rel="next') > -1) {
                                     var nextPage = link.match(/\?page=(\d+)/)[1];
 
@@ -188,6 +196,9 @@ angular.module('gisto.service.gitHubAPI', [
                                 }
                             }
                         });
+						
+						//console.log("categories?");
+						//console.log(gistData.categories);
 
                     }).error(function (data, status, headers, config) {
                         console.log({


### PR DESCRIPTION
This problem was not solved: [https://github.com/Gisto/Gisto/issues/103]

Because if the user has more than 10 pages of gists the API only shows the final page.
Like: https://api.github.com/gists?page=46

My fix iterates from the current page (which is then 9) to the final page number (which is in my case 46).

I can provide a text github account with 1400 gists, to test that.

---

I also improved the search:
now search not only in the description but also in the first filename.

you can combine terms that need to match with spaces.
like: split php
which will find any gist that has split and php, either in the
description or the filename

and you can also use quotes for exact matches
like "split php"

Demovideo:
http://www.youtube.com/watch?v=kYVXmGOsFDU
