### PR TITLE
Add new search option to Gists.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -90,7 +90,7 @@
 
     <ul data-hotkeys-pager="navigateToGist" style="position:relative;">
         <li data-hotkeys-pager-item="{{gist.id}}" id="gist-{{gist.id}}" class="animate-list"
-            data-ng-repeat="gist in filteredGists = (gists | filter:search) | orderBy:'-created_at'">
+            data-ng-repeat="gist in filteredGists = (gists | gistFilter: search ) | orderBy:'-created_at'">
             <a ui-route="/gist/{{gist.id}}" data-ng-class="{active: $uiRoute}"
                ng-click="navigateToGist(gist.id)">
                 <h3>
@@ -200,6 +200,7 @@
 <script src="js/filters/dotToDash.js"></script>
 <script src="js/filters/matchTagsFilter.js"></script>
 <script src="js/filters/githubFileName.js"></script>
+<script src="js/filters/gistFilter.js"></script>
 <script src="js/directives/editorDirective.js"></script>
 <script src="js/directives/scrollDirective.js"></script>
 <script src="js/directives/goToUrlDirective.js"></script>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -22,6 +22,7 @@ var app = angular.module('gisto', [
     'gisto.filter.matchTags',
     'gisto.filter.dotToDash',
     'gisto.filter.githubFileName',
+    'gisto.filter.gist',
     'gisto.directive.scrollTo',
     'gisto.directive.editor',
     'gisto.directive.toUrl',

--- a/app/js/controllers/settingsController.js
+++ b/app/js/controllers/settingsController.js
@@ -22,6 +22,7 @@
             $scope.editor_vim_mode = result['editor_vim_mode'] || false;
             $scope.editor_word_wrap = result['editor_word_wrap'] || false;
             $rootScope.ui_zoom = $scope.ui_zoom = result['ui_zoom'] || 100;
+            $rootScope.gist_cs_wrap_search = $scope.gist_cs_wrap_search = result['gist_cs_wrap_search'] || false;
         }, function (error) {
             console.log('could not load settings');
         });
@@ -54,6 +55,7 @@
             $rootScope.ui_zoom = data.ui_zoom = $scope.ui_zoom;
             data.min_lines = $scope.min_lines;
             data.max_lines = $scope.max_lines;
+            data.gist_cs_wrap_search = $scope.gist_cs_wrap_search;
             appSettings.set(data);
             $('.ok').slideDown('slow');
             setTimeout(function () {

--- a/app/js/filters/gistFilter.js
+++ b/app/js/filters/gistFilter.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('gisto.filter.gist', []).filter('gistFilter', function (appSettings, $filter) {
+        return function(arr, searchString) {
+            if (!searchString) {
+                return arr;
+            }
+
+            // uses the Case Sensitive Wrapabble search
+            if (appSettings.get('gist_cs_wrap_search')) {
+
+                var pattern = '';
+                for (var i = 0; i < searchString.length; i++) {
+                    pattern += searchString[i] + '.*';
+                }
+                
+                var result = [];
+                angular.forEach(arr, function(item) {
+
+                    if (item.description.match(pattern)) {
+                        result.push(item);
+                    }
+                });
+
+                return result;
+            } else { 
+                // uses angular default deep search over all gists list fields
+                return $filter('filter')(arr, searchString);
+            }
+        };
+    });

--- a/app/js/services/settingsService.js
+++ b/app/js/services/settingsService.js
@@ -45,6 +45,7 @@ angular.module('gisto.service.appSettings', [], function ($provide) {
                 theme: 'default',
                 editor_theme: 'tomorrow',
                 new_gist_public: false,
+                gist_cs_wrap_search: false,
                 editor_ext: { emmet: false, statusbar: false, autocompletion: false },
                 editor_vim_mode: false,
                 min_lines: 0,

--- a/app/partials/settings.html
+++ b/app/partials/settings.html
@@ -75,6 +75,8 @@
         <details><summary>Defaults</summary>
 
             <toggle data-ng-model="new_gist_public" text="New Gists I create are public"></toggle>
+            <br/>
+            <toggle data-ng-model="gist_cs_wrap_search" text="Search by Gists description in a case sensitive and wrappable way (example: search: 'ISV', result: 'Ionic Simple View', 'Ionic Material Simple View')"></toggle>
 
         </details>
 


### PR DESCRIPTION
Hi, I have started using Gisto and I found it a very useful tool. The only thing that I have to complain is the Gist search... So I decided to try to contribute to the project by adding a new search option in the settings menu. This search option is case sensitive and works almost like in most of the file search in the editors, in particular similar to Eclipse's CTRL+SHIFT+R. 

Here are some examples:
**Initial List:**

Ionic Search Button
Ionic Material Floating Action
Ionic Simple Material Navbar 

**Search applied:** IFA
**Result:** 
Ionic Material Floating Action

**Search applied:** IMat
**Result:** 
Ionic Material Floating Action
Ionic Simple Material Navbar 


It's simple, but it can help a lot for quick search when there's a lot of Gists...

Regards,
William