### PR TITLE
docs: Fix installation instructions in Downloads.js

### DIFF
--- a/docs/src/components/Downloads.js
+++ b/docs/src/components/Downloads.js
@@ -199,7 +199,7 @@ class Downloads extends Component {
                     </p>
 
                     <pre>
-                      <span>SHELL</span>$ brew cask install gisto
+                      <span>SHELL</span>$ brew install --cask gisto
                     </pre>
                     <small>Please note that it might be slightly outdated version</small>
                     <br />


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but this page needs to be fixed.

Close #306 