### PR TITLE
feat(editor): support 1c language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All significant updates and improvements
 
+## Upcoming version
+
+[test build](https://main-branch-gisto-app.netlify.app/)
+
+### 🚀 Features
+
+- *(editor)* Support 1c language
+・ by Sasha Khamkov
+([781e66e](https://github.com/gisto/gisto/commit/781e66e4db444dc7e7af41ed6bd6159573abe5d5))
+
+
 ## v2.2.8
 
 Released on: Aug 2, 2025

--- a/src/components/layout/pages/snippet/content/editor.tsx
+++ b/src/components/layout/pages/snippet/content/editor.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 
 import type { Monaco } from '@monaco-editor/react';
 
+import bslLanguage from '@/components/layout/pages/snippet/content/monarchs/bsl.monarch';
 import groovyLanguage from '@/components/layout/pages/snippet/content/monarchs/groovy.monarch';
 import { Csv } from '@/components/layout/pages/snippet/content/preview/csv.tsx';
 import { GeoJson } from '@/components/layout/pages/snippet/content/preview/geo-json.tsx';
@@ -134,6 +135,13 @@ export const Editor = ({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       groovyLanguage
+    );
+    monaco.languages.register({ id: 'bsl', extensions: ['.bsl', '.os'] });
+    monaco.languages.setMonarchTokensProvider(
+      'bsl',
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      bslLanguage
     );
   };
 

--- a/src/components/layout/pages/snippet/content/monarchs/bsl.monarch.ts
+++ b/src/components/layout/pages/snippet/content/monarchs/bsl.monarch.ts
@@ -1,0 +1,50 @@
+const bslLanguage = {
+  keywords: [
+    'Процедура',
+    'Функция',
+    'КонецПроцедуры',
+    'КонецФункции',
+    'Если',
+    'Тогда',
+    'Иначе',
+    'Для',
+    'Каждого',
+    'Пока',
+    'Возврат',
+    'Перем',
+    'Экспорт',
+    'Попытка',
+    'Исключение',
+    'КонецПопытки',
+    'ВызватьИсключение',
+  ],
+  operators: ['=', '<>', '<', '>', '<=', '>=', '+', '-', '*', '/', '%', 'НЕ', 'И', 'ИЛИ'],
+  // eslint-disable-next-line no-useless-escape
+  symbols: /[=><!~?:&|+\-*\/\^%]+/,
+
+  tokenizer: {
+    root: [
+      // keywords / identifiers
+      [
+        /[а-яА-Я_][а-яА-Я0-9_]*/,
+        {
+          cases: {
+            '@keywords': 'keyword',
+            '@default': 'identifier',
+          },
+        },
+      ],
+
+      // numbers
+      [/\d+/, 'number'],
+
+      // strings
+      [/".*?"/, 'string'],
+
+      // comments
+      [/\/\/.*$/, 'comment'],
+    ],
+  },
+};
+
+export default bslLanguage;

--- a/src/constants/language-map.ts
+++ b/src/constants/language-map.ts
@@ -1,5 +1,6 @@
 // This maps gist file language to monaco editor equivalent
 export const languageMap: Record<string, string> = {
+  "1C Enterprise": "bsl",
   ABAP: 'abap',
   ActionScript: 'actionscript',
   Ada: 'ada',


### PR DESCRIPTION
add support for 1C Enterprise language and basic language monarch for monaco-editor

fix #517