### PR TITLE
fix: add MiniMax endpoint configuration

### DIFF
--- a/src/components/layout/pages/settings/dynamic-settings.tsx
+++ b/src/components/layout/pages/settings/dynamic-settings.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/select.tsx';
 import { Slider } from '@/components/ui/slider.tsx';
 import { Switch } from '@/components/ui/switch.tsx';
-import { AI_PROVIDERS } from '@/constants';
+import { AI_PROVIDERS, MINIMAX_PROTOCOL_OPTIONS, MINIMAX_REGION_OPTIONS } from '@/constants';
 import { languageMap } from '@/constants/language-map.ts';
 import { useAiModels } from '@/hooks/use-ai-models';
 import { t } from '@/lib/i18n';
@@ -585,6 +585,29 @@ export const DynamicSettings = ({ settings, onChange, path = '' }: SettingsProps
                   </SelectContent>
                 </Select>
               </div>
+            );
+          }
+
+          if (key === 'minimaxRegion' || key === 'minimaxProtocol') {
+            const aiSettings = path === 'ai' ? (settings as Record<string, unknown>) : null;
+            const activeProvider = (aiSettings?.activeAiProvider as string) || 'openrouter';
+
+            if (activeProvider !== 'minimax') {
+              return null;
+            }
+
+            return (
+              <SpecialSelect
+                key={key}
+                settingKey={key}
+                value={value}
+                onChange={onChange}
+                fullPath={fullPath}
+                options={
+                  key === 'minimaxRegion' ? MINIMAX_REGION_OPTIONS : MINIMAX_PROTOCOL_OPTIONS
+                }
+                label={key === 'minimaxRegion' ? 'MiniMax region' : 'API protocol'}
+              />
             );
           }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,3 +12,4 @@ export const EDITOR_OPTIONS = {
 };
 
 export * from './ai-providers';
+export * from './minimax-endpoints';

--- a/src/constants/minimax-endpoints.ts
+++ b/src/constants/minimax-endpoints.ts
@@ -1,0 +1,46 @@
+export type MiniMaxRegion = 'global_en' | 'cn_zh';
+export type MiniMaxProtocol = 'openai' | 'anthropic';
+
+export const MINIMAX_REGION_OPTIONS: { value: MiniMaxRegion; label: string }[] = [
+  { value: 'global_en', label: 'Global' },
+  { value: 'cn_zh', label: 'China' },
+];
+
+export const MINIMAX_PROTOCOL_OPTIONS: { value: MiniMaxProtocol; label: string }[] = [
+  { value: 'openai', label: 'OpenAI-compatible' },
+  { value: 'anthropic', label: 'Anthropic-compatible' },
+];
+
+const MINIMAX_BASE_URLS: Record<MiniMaxRegion, Record<MiniMaxProtocol, string>> = {
+  global_en: {
+    openai: 'https://api.minimax.io/v1',
+    anthropic: 'https://api.minimax.io/anthropic',
+  },
+  cn_zh: {
+    openai: 'https://api.minimaxi.com/v1',
+    anthropic: 'https://api.minimaxi.com/anthropic',
+  },
+};
+
+function isMiniMaxRegion(value: unknown): value is MiniMaxRegion {
+  return value === 'global_en' || value === 'cn_zh';
+}
+
+function isMiniMaxProtocol(value: unknown): value is MiniMaxProtocol {
+  return value === 'openai' || value === 'anthropic';
+}
+
+export function resolveMiniMaxEndpoint(region: unknown, protocol: unknown) {
+  const resolvedRegion = isMiniMaxRegion(region) ? region : 'global_en';
+  const resolvedProtocol = isMiniMaxProtocol(protocol) ? protocol : 'openai';
+  const baseUrl = MINIMAX_BASE_URLS[resolvedRegion][resolvedProtocol];
+
+  return {
+    region: resolvedRegion,
+    protocol: resolvedProtocol,
+    baseUrl,
+    chatUrl:
+      resolvedProtocol === 'anthropic' ? `${baseUrl}/v1/messages` : `${baseUrl}/chat/completions`,
+    modelsUrl: resolvedProtocol === 'anthropic' ? `${baseUrl}/v1/models` : `${baseUrl}/models`,
+  };
+}

--- a/src/lib/api/ai-api.test.ts
+++ b/src/lib/api/ai-api.test.ts
@@ -163,30 +163,85 @@ describe('generateAiResponse', () => {
     fetchSpy.mockRestore();
   });
 
-  it('sends requests to the MiniMax OpenAI-compatible endpoint', async () => {
-    mockSettings.ai = {
-      activeAiProvider: 'minimax',
-      minimaxApiKey: 'test-key',
-      model: 'MiniMax-M3',
-      temperature: 0.7,
-    };
+  it.each([
+    {
+      name: 'global OpenAI-compatible',
+      region: 'global_en',
+      protocol: 'openai',
+      endpoint: 'https://api.minimax.io/v1/chat/completions',
+    },
+    {
+      name: 'China OpenAI-compatible',
+      region: 'cn_zh',
+      protocol: 'openai',
+      endpoint: 'https://api.minimaxi.com/v1/chat/completions',
+    },
+    {
+      name: 'global Anthropic-compatible',
+      region: 'global_en',
+      protocol: 'anthropic',
+      endpoint: 'https://api.minimax.io/anthropic/v1/messages',
+    },
+    {
+      name: 'China Anthropic-compatible',
+      region: 'cn_zh',
+      protocol: 'anthropic',
+      endpoint: 'https://api.minimaxi.com/anthropic/v1/messages',
+    },
+  ])(
+    'routes MiniMax requests through the $name endpoint',
+    async ({ region, protocol, endpoint }) => {
+      mockSettings.ai = {
+        activeAiProvider: 'minimax',
+        minimaxApiKey: 'test-key',
+        minimaxRegion: region,
+        minimaxProtocol: protocol,
+        model: 'MiniMax-M3',
+        temperature: 0.7,
+      };
 
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ choices: [{ message: { content: 'MiniMax response' } }] }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    );
+      const responseBody =
+        protocol === 'anthropic'
+          ? {
+              content: [
+                { type: 'thinking', thinking: 'Internal reasoning' },
+                { type: 'text', text: 'MiniMax response' },
+              ],
+            }
+          : { choices: [{ message: { content: 'MiniMax response' } }] };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(responseBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
 
-    const result = await generateAiResponse({ prompt: 'hello' });
+      const result = await generateAiResponse({
+        prompt: 'hello',
+        systemContext: 'Follow the requested format.',
+      });
 
-    expect(result).toBe('MiniMax response');
-    expect(fetchSpy.mock.calls[0][0]).toBe('https://api.minimax.io/v1/chat/completions');
-    const callBody = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
-    expect(callBody.model).toBe('MiniMax-M3');
+      expect(result).toBe('MiniMax response');
+      expect(fetchSpy.mock.calls[0][0]).toBe(endpoint);
+      const request = fetchSpy.mock.calls[0][1];
+      const headers = request?.headers as Record<string, string>;
+      const callBody = JSON.parse(request?.body as string);
+      expect(callBody.model).toBe('MiniMax-M3');
+      if (protocol === 'anthropic') {
+        expect(headers['x-api-key']).toBe('test-key');
+        expect(callBody.system).toBe('Follow the requested format.');
+        expect(callBody.max_tokens).toBe(4096);
+      } else {
+        expect(headers.Authorization).toBe('Bearer test-key');
+        expect(callBody.messages[0]).toEqual({
+          role: 'system',
+          content: 'Follow the requested format.',
+        });
+      }
 
-    fetchSpy.mockRestore();
-  });
+      fetchSpy.mockRestore();
+    }
+  );
 
   it('cleans JSON code fences from response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(

--- a/src/lib/api/ai-api.ts
+++ b/src/lib/api/ai-api.ts
@@ -1,10 +1,11 @@
 import { globalState } from '../store/globalState.ts';
 
+import { resolveMiniMaxEndpoint } from '@/constants/minimax-endpoints.ts';
+
 const GEMINI_ENDPOINT =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
 const OPENROUTER_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
 const OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
-const MINIMAX_ENDPOINT = 'https://api.minimax.io/v1/chat/completions';
 const CLAUDE_ENDPOINT = 'https://api.anthropic.com/v1/messages';
 
 export interface ChatMessage {
@@ -47,8 +48,8 @@ type GeminiResponse = {
   candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
 };
 
-type ClaudeResponse = {
-  content?: Array<{ text?: string }>;
+type AnthropicChatResponse = {
+  content?: Array<{ type?: string; text?: string }>;
 };
 
 export class AiApiError extends Error {
@@ -121,6 +122,10 @@ export async function generateAiResponse(options: GenerateAiResponseOptions): Pr
   // Get the active provider and its API key
   const activeAiProvider = (ai.activeAiProvider || 'openrouter') as AiProvider;
   const apiKey = ai[AI_PROVIDER_API_KEYS[activeAiProvider]] || '';
+  const minimaxEndpoint =
+    activeAiProvider === 'minimax'
+      ? resolveMiniMaxEndpoint(ai.minimaxRegion, ai.minimaxProtocol)
+      : null;
 
   if (!apiKey) {
     throw new AiApiError(
@@ -163,8 +168,12 @@ export async function generateAiResponse(options: GenerateAiResponseOptions): Pr
 
     const res = await parseJsonResponse<OpenRouterChatResponse>(response, 'openrouter');
     rawResponse = res.choices?.[0]?.message?.content ?? '';
-  } else if (activeAiProvider === 'openai' || activeAiProvider === 'minimax') {
-    const endpoint = activeAiProvider === 'minimax' ? MINIMAX_ENDPOINT : OPENAI_ENDPOINT;
+  } else if (
+    activeAiProvider === 'openai' ||
+    (activeAiProvider === 'minimax' && minimaxEndpoint?.protocol === 'openai')
+  ) {
+    const endpoint =
+      activeAiProvider === 'minimax' && minimaxEndpoint ? minimaxEndpoint.chatUrl : OPENAI_ENDPOINT;
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
@@ -194,34 +203,42 @@ export async function generateAiResponse(options: GenerateAiResponseOptions): Pr
 
     const res = await parseJsonResponse<GeminiResponse>(response, 'gemini');
     rawResponse = res.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-  } else if (activeAiProvider === 'claude') {
-    const claudeMessages = buildMessages(prompt, chatMessages, systemContext);
-    const claudeSystem =
-      claudeMessages
+  } else if (
+    activeAiProvider === 'claude' ||
+    (activeAiProvider === 'minimax' && minimaxEndpoint?.protocol === 'anthropic')
+  ) {
+    const anthropicMessages = buildMessages(prompt, chatMessages, systemContext);
+    const anthropicSystem =
+      anthropicMessages
         .filter((m) => m.role === 'system')
         .map((m) => m.content)
         .join('\n') || undefined;
-    const claudeBody: Record<string, unknown> = {
+    const anthropicBody: Record<string, unknown> = {
       model,
       max_tokens: 4096,
-      messages: claudeMessages.filter((m) => m.role !== 'system'),
+      messages: anthropicMessages.filter((m) => m.role !== 'system'),
       temperature,
     };
-    if (claudeSystem) {
-      claudeBody.system = claudeSystem;
+    if (anthropicSystem) {
+      anthropicBody.system = anthropicSystem;
     }
-    const response = await fetch(CLAUDE_ENDPOINT, {
+    const endpoint =
+      activeAiProvider === 'minimax' && minimaxEndpoint ? minimaxEndpoint.chatUrl : CLAUDE_ENDPOINT;
+    const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'x-api-key': apiKey,
         'anthropic-version': '2023-06-01',
       },
-      body: JSON.stringify(claudeBody),
+      body: JSON.stringify(anthropicBody),
     });
 
-    const res = await parseJsonResponse<ClaudeResponse>(response, 'claude');
-    rawResponse = res.content?.[0]?.text ?? '';
+    const res = await parseJsonResponse<AnthropicChatResponse>(response, activeAiProvider);
+    rawResponse =
+      res.content?.find((block) => block.type === 'text')?.text ??
+      res.content?.find((block) => block.text)?.text ??
+      '';
   } else {
     throw new AiApiError('Invalid AI provider configured.', activeAiProvider);
   }

--- a/src/lib/api/models-api.test.ts
+++ b/src/lib/api/models-api.test.ts
@@ -27,7 +27,37 @@ describe('fetchMiniMaxModels', () => {
     vi.restoreAllMocks();
   });
 
-  it('fetches and maps models from the OpenAI-compatible endpoint', async () => {
+  it.each([
+    {
+      name: 'global OpenAI-compatible',
+      region: 'global_en',
+      protocol: 'openai',
+      endpoint: 'https://api.minimax.io/v1/models',
+    },
+    {
+      name: 'China OpenAI-compatible',
+      region: 'cn_zh',
+      protocol: 'openai',
+      endpoint: 'https://api.minimaxi.com/v1/models',
+    },
+    {
+      name: 'global Anthropic-compatible',
+      region: 'global_en',
+      protocol: 'anthropic',
+      endpoint: 'https://api.minimax.io/anthropic/v1/models',
+    },
+    {
+      name: 'China Anthropic-compatible',
+      region: 'cn_zh',
+      protocol: 'anthropic',
+      endpoint: 'https://api.minimaxi.com/anthropic/v1/models',
+    },
+  ])('fetches and maps models from the $name endpoint', async ({ region, protocol, endpoint }) => {
+    mockSettings.ai = {
+      minimaxApiKey: 'test-key',
+      minimaxRegion: region,
+      minimaxProtocol: protocol,
+    };
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -44,9 +74,13 @@ describe('fetchMiniMaxModels', () => {
       { id: 'MiniMax-M3', name: 'MiniMax-M3' },
       { id: 'MiniMax-M2.7', name: 'MiniMax-M2.7' },
     ]);
-    expect(fetchSpy).toHaveBeenCalledWith('https://api.minimax.io/v1/models', {
-      headers: { Authorization: 'Bearer test-key' },
-    });
+    expect(fetchSpy.mock.calls[0][0]).toBe(endpoint);
+    const headers = fetchSpy.mock.calls[0][1]?.headers as Record<string, string>;
+    if (protocol === 'anthropic') {
+      expect(headers['x-api-key']).toBe('test-key');
+    } else {
+      expect(headers.Authorization).toBe('Bearer test-key');
+    }
   });
 
   it('does not call the API without a configured key', async () => {

--- a/src/lib/api/models-api.ts
+++ b/src/lib/api/models-api.ts
@@ -1,3 +1,4 @@
+import { resolveMiniMaxEndpoint } from '@/constants/minimax-endpoints.ts';
 import { t } from '@/lib/i18n';
 import { globalState } from '@/lib/store/globalState.ts';
 
@@ -108,8 +109,14 @@ export async function fetchMiniMaxModels(): Promise<ModelInfo[]> {
   const apiKey = getApiKey('minimax');
   if (!apiKey) throw new Error(t('api.configureAiProvider'));
 
-  const res = await fetch('https://api.minimax.io/v1/models', {
-    headers: { Authorization: `Bearer ${apiKey}` },
+  const { ai } = globalState.getState().settings;
+  const endpoint = resolveMiniMaxEndpoint(ai.minimaxRegion, ai.minimaxProtocol);
+
+  const res = await fetch(endpoint.modelsUrl, {
+    headers:
+      endpoint.protocol === 'anthropic'
+        ? { 'x-api-key': apiKey }
+        : { Authorization: `Bearer ${apiKey}` },
   });
 
   if (!res.ok) throw new Error(`MiniMax API error: ${res.status}`);

--- a/src/lib/store/globalState.ts
+++ b/src/lib/store/globalState.ts
@@ -56,6 +56,8 @@ export type StoreStateType = {
       openaiApiKey?: string;
       claudeApiKey?: string;
       minimaxApiKey?: string;
+      minimaxRegion: 'global_en' | 'cn_zh';
+      minimaxProtocol: 'openai' | 'anthropic';
       model: string;
       temperature: number;
       cleanJson: boolean;
@@ -168,6 +170,8 @@ export const defaultSettings: SettingsType = {
     openaiApiKey: '',
     claudeApiKey: '',
     minimaxApiKey: '',
+    minimaxRegion: 'global_en',
+    minimaxProtocol: 'openai',
     model: 'meta-llama/llama-3.2-3b-instruct:free',
     temperature: 0.7,
     cleanJson: true,


### PR DESCRIPTION
Follow-up to #611.

## Summary
- Add MiniMax region and API protocol selectors while preserving the existing default.
- Route chat requests through the selected global or China OpenAI-compatible or Anthropic-compatible endpoint.
- Use the same endpoint selection for authenticated model discovery.

## Tests
- `pnpm exec vitest run src/lib/api/ai-api.test.ts src/lib/api/models-api.test.ts` (19 tests)
- `pnpm ts:lint`
- `pnpm lint`
- `pnpm test` (281 tests)
- `pnpm e2e` (21 tests)
